### PR TITLE
refactor: handle dynamic kernel size lookup

### DIFF
--- a/process_audio.py
+++ b/process_audio.py
@@ -131,8 +131,13 @@ model = WhisperModel("large-v3", device="cuda" if torch.cuda.is_available() else
 pipeline = Pipeline.from_pretrained("pyannote/speaker-diarization-3.1")
 audio_reader = Audio(sample_rate=16000)
 embedding_model = Model.from_pretrained("pyannote/embedding")
-first_layer = next(embedding_model.sincnet.children())
-ks = first_layer.kernel_size
+ks = None
+for layer in embedding_model.sincnet.modules():
+    if hasattr(layer, "kernel_size"):
+        ks = layer.kernel_size
+        break
+if ks is None:
+    raise RuntimeError("No layer with kernel_size found in SincNet")
 min_len = ks if isinstance(ks, int) else ks[0]
 
 all_embeddings = []


### PR DESCRIPTION
## Summary
- ensure SincNet minimum segment length is obtained from the first layer exposing `kernel_size`

## Testing
- `python -m py_compile process_audio.py`


------
https://chatgpt.com/codex/tasks/task_e_688e8140d46c83208d90228534d0c1df