### PR TITLE
Handle short audio segments before batching

### DIFF
--- a/process_audio.py
+++ b/process_audio.py
@@ -161,14 +161,15 @@ for idx, audio_path in enumerate(wav_files, 1):
     for seg in diarization.itertracks(yield_label=True):
         turn, _, speaker = seg
         segment_audio = waveform[:, int(turn.start * sample_rate):int(turn.end * sample_rate)]
-        segment_tensor = (
-            segment_audio if torch.is_tensor(segment_audio)
-            else torch.from_numpy(segment_audio)
-        ).float().unsqueeze(0)
-        if segment_tensor.shape[-1] < min_len:
-            segment_tensor = F.pad(segment_tensor, (0, min_len - segment_tensor.shape[-1]))
-        if segment_tensor.shape[-1] < min_len:
+        segment_audio = (
+            segment_audio if torch.is_tensor(segment_audio) else torch.from_numpy(segment_audio)
+        )
+        seg_len = segment_audio.shape[-1]
+        if seg_len < min_len:
+            segment_audio = F.pad(segment_audio, (0, min_len - seg_len))
+        if segment_audio.shape[-1] < min_len:
             continue
+        segment_tensor = segment_audio.unsqueeze(0).float()
         with torch.no_grad():
             emb_tensor = embedding_model(segment_tensor)
         emb_np = emb_tensor.squeeze(0).cpu().numpy()


### PR DESCRIPTION
## Summary
- ensure short diarized segments are padded or skipped before batching

## Testing
- `python -m py_compile process_audio.py`


------
https://chatgpt.com/codex/tasks/task_e_688e835e640c8320852d694009eaabde