### PR TITLE
Use first TDNN layer for segment padding

### DIFF
--- a/process_audio.py
+++ b/process_audio.py
@@ -139,10 +139,13 @@ sinc_ks = (
     if isinstance(sinc_layer.kernel_size, (tuple, list))
     else sinc_layer.kernel_size
 )
+tdnn_layer = next(
+    m for m in embedding_model.tdnns if hasattr(m, "kernel_size")
+)
 tdnn_ks = (
-    embedding_model.tdnn1.kernel_size[0]
-    if isinstance(embedding_model.tdnn1.kernel_size, (tuple, list))
-    else embedding_model.tdnn1.kernel_size
+    tdnn_layer.kernel_size[0]
+    if isinstance(tdnn_layer.kernel_size, (tuple, list))
+    else tdnn_layer.kernel_size
 )
 min_len = sinc_ks + tdnn_ks - 1
 


### PR DESCRIPTION
## Summary
- Determine TDNN kernel size from the first layer in `embedding_model.tdnns` instead of using `tdnn1`
- Compute minimum segment length with the dynamic TDNN kernel size

## Testing
- `python -m py_compile process_audio.py`
- `python -m pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688e8cb5cf648320afd9c2d38c6f772f